### PR TITLE
feat: update add-on after migration to ddev org

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,17 +15,9 @@ on:
         required: false
         default: false
 
-defaults:
-  run:
-    shell: bash
-
-# This is required for "gautamkrishnar/keepalive-workflow"
+# This is required for "gautamkrishnar/keepalive-workflow", see "ddev/github-action-add-on-test"
 permissions:
-  contents: write
-
-env:
-  # Allow ddev get to use a GitHub token to prevent rate limiting by tests
-  DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  actions: write
 
 jobs:
   tests:
@@ -38,10 +30,10 @@ jobs:
         ddev_version: [stable, HEAD]
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v1
+    - uses: ddev/github-action-add-on-test@v2
       with:
         ddev_version: ${{ matrix.ddev_version }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# DDEV opensearch Addon
+# DDEV OpenSearch Add-on
 
-This addon sets up two services in your [ddev](https://ddev.com) project.
+This addon sets up two services in your [DDEV](https://ddev.com) project.
 
 - [OpenSearch](https://opensearch.org/) service (Docker Image: `opensearchproject/opensearch:latest`)
 - [OpenSearch Dashboards](https://opensearch.org/) service (Docker Image: `opensearchproject/opensearch-dashboards:latestopensearch:latest`)
 
-We activat this plugins out-of-the-box:
+We activate these plugins out-of-the-box:
 - analysis-phonetic
 - analysis-icu
 
-To change the version update the `.ddev/opensearch/Dockerfile` for the main OpenSearch Service.
-Update the file `.ddev/docker-compose.opensearch.yaml` for a compartible Dashboards version.
+To change the version, update the `.ddev/opensearch/Dockerfile` for the main OpenSearch Service.
+Update the file `.ddev/docker-compose.opensearch.yaml` for a compatible Dashboards version.
 
 ## Installation
 
-1. Run `ddev get netz98/ddev-opensearch` to install the addon in your exiting ddev project.
+1. Run `ddev get ddev/ddev-opensearch` to install the addon in your exiting DDEV project.
 2. `ddev restart` to restart your project.
 
 ## Usage
@@ -27,6 +27,10 @@ Run `ddev describe` to list your project's services and their URLs.
 
 ## Logging
 
-All logs are directed to the container's stdout. 
+All logs are directed to the container's stdout.
 
 You can view the logs with `ddev logs -s opensearch` and `ddev logs -s opensearch-dashboards`
+
+**Contributed and maintained by [@cmuench](https://github.com/cmuench) from [@netz98](https://github.com/netz98) org**
+
+**Co-maintained by [@stasadev](https://github.com/stasadev)**

--- a/docker-compose.opensearch.yaml
+++ b/docker-compose.opensearch.yaml
@@ -1,22 +1,21 @@
 #ddev-generated
-version: '3.6'
 services:
   opensearch:
     container_name: ddev-${DDEV_SITENAME}-opensearch
-    hostname: ${DDEV_SITENAME}-opensearch
     build: ./opensearch
     expose:
-      - "9200"
-    networks: [default, ddev_default]
+      - 9200
     environment:
+      # see https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/ for available options
       # disables installation of demo data
       - "DISABLE_INSTALL_DEMO_CONFIG=true"
       # disables security plugin
       - "DISABLE_SECURITY_PLUGIN=true"
-      - cluster.name=docker-cluster
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node
       - discovery.type=single-node
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTP_EXPOSE=9200:9200
       - HTTPS_EXPOSE=9201:9200
@@ -26,21 +25,21 @@ services:
     volumes:
       - opensearch:/usr/share/opensearch/data
       - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail -s localhost:9200"]
 
   opensearch-dashboards:
     image: opensearchproject/opensearch-dashboards:latest
     container_name: 'ddev-${DDEV_SITENAME}-opensearch-dashboards'
-    hostname: '${DDEV_SITENAME}-opensearch-dashboards'
-    networks: [default, ddev_default]
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - OPENSEARCH_HOSTS=http://ddev-${DDEV_PROJECT}-opensearch:9200
       - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true" # disables security plugin
-      - SERVER_NAME=ddev-${DDEV_PROJECT}-opensearch
       - HTTP_EXPOSE=5601:5601
       - HTTPS_EXPOSE=5602:5601
-    expose:      
-      - "5601"
+    expose:
+      - 5601
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
@@ -50,8 +49,6 @@ services:
   web:
     depends_on:
       - opensearch
-    links:
-      - 'opensearch:opensearch'
 
 volumes:
   opensearch:


### PR DESCRIPTION
## The Issue

- #1

## How This PR Solves The Issue

1. I want to become a maintainer because I use OpenSearch (and have my own config), but I never knew about this add-on.
2. Update tests.yml to the latest [one](https://github.com/ddev/ddev-addon-template/blob/main/.github/workflows/tests.yml).
3. Update docker-compose.opensearch.yaml:
  - remove `version`, `networks`, `links` as not needed
  - remove `hostname` - I never actually set this setting, and didn't see it in the official DDEV add-ons
  - rename `ES_JAVA_OPTS` to `OPENSEARCH_JAVA_OPTS`
  - use `cluster.name` and `node.name` from the [official docs](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/).
  - remove `SERVER_NAME` from opensearch-dashboards - I don't know why this needed.
  - add `healthcheck`

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

