### PR TITLE
Add missing ddev-generate in Dockerfile

### DIFF
--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -1,3 +1,4 @@
+#ddev-generated
 FROM opensearchproject/opensearch:latest
 WORKDIR /usr/share/opensearch
  


### PR DESCRIPTION
## The Issue

A ddev-generate is missing which prevent that ppl can override the logic.

## How This PR Solves The Issue

Add them missing ddev-generate comment in the Dockerfile

## Manual Testing Instructions

Install the plugin an modify the installed Dockerfile by removing the ddev-generated comment.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

issue #4


