### PR TITLE
feature: dotenv support - allow to change the used OpenSearch version (ddev 1.23.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ ddev dotenv set .ddev/.env.opensearch \
     --opensearch-dashboards-tag=2.15.0 \
     --install-plugin-analytics-phonetic=false \ 
     --install-plugin-analytics-icu=false
+
+# rebuild opensearch image (required step)
+ddev debug rebuild -s opensearch
+
+# remove old opensearch volume (if this is downgrade)
+ddev stop
+docker volume rm ddev-$(ddev status -j | docker run -i --rm ddev/ddev-utilities jq -r '.raw.name')_opensearch
+
+# and restart the project
+ddev restart
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Example:
 ddev dotenv set .ddev/.env.opensearch \
     --opensearch-tag=2.15.0 \
     --opensearch-dashboards-tag=2.15.0 \
-    --install-plugin-analytics-phonetic=false \ --install-plugin-analytics-icu=false
+    --install-plugin-analytics-phonetic=false \ 
+    --install-plugin-analytics-icu=false
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -14,8 +14,28 @@ Update the file `.ddev/docker-compose.opensearch.yaml` for a compatible Dashboar
 
 ## Installation
 
-1. Run `ddev get ddev/ddev-opensearch` to install the addon in your exiting DDEV project.
+1. Run `ddev add-on get ddev/ddev-opensearch` to install the addon in your exiting DDEV project.
 2. `ddev restart` to restart your project.
+
+## Configuration
+
+To modify the build of the used OpenSearch image for the container there are dotenv variables available.
+
+- `OPENSEARCH_TAG` - The version of the OpenSearch image to use. Default: `latest`
+- `OPENSEARCH_DASHBOARDS_TAG` - The version of the OpenSearch Dashboards image to use. Default: `latest`
+- `INSTALL_PLUGIN_ANALYSIS_PHONETIC` - Install the analysis-phonetic plugin. Default: `true`
+- `INSTALL_PLUGIN_ANALYSIS_ICU` - Install the analysis-icu plugin. Default: `true`
+
+Use the `ddev dotenv` command to set these variables.
+
+Example:
+
+```bash
+ddev dotenv set .ddev/.env.opensearch \
+    --opensearch-tag=2.15.0 \
+    --opensearch-dashboards-tag=2.15.0 \
+    --install-plugin-analytics-phonetic=false \ --install-plugin-analytics-icu=false
+```
 
 ## Usage
 

--- a/docker-compose.opensearch.yaml
+++ b/docker-compose.opensearch.yaml
@@ -36,7 +36,7 @@ services:
       test: ["CMD-SHELL", "curl --fail -s localhost:9200"]
 
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:latest
+    image: opensearchproject/opensearch-dashboards:${OPENSEARCH_DASHBOARDS_TAG:-latest}
     container_name: 'ddev-${DDEV_SITENAME}-opensearch-dashboards'
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME

--- a/docker-compose.opensearch.yaml
+++ b/docker-compose.opensearch.yaml
@@ -2,7 +2,13 @@
 services:
   opensearch:
     container_name: ddev-${DDEV_SITENAME}-opensearch
-    build: ./opensearch
+    build: 
+      context: ./opensearch
+      dockerfile: Dockerfile
+      args:
+        OPENSEARCH_TAG: ${OPENSEARCH_TAG:-latest}
+        INSTALL_PLUGIN_ANALYSIS_PHONETIC: ${INSTALL_PLUGIN_ANALYSIS_PHONETIC:-true}
+        INSTALL_PLUGIN_ANALYSIS_ICU: ${INSTALL_PLUGIN_ANALYSIS_ICU:-true}
     expose:
       - 9200
     environment:

--- a/opensearch/Dockerfile
+++ b/opensearch/Dockerfile
@@ -1,6 +1,13 @@
 #ddev-generated
-FROM opensearchproject/opensearch:latest
+ARG OPENSEARCH_TAG=latest
+
+FROM opensearchproject/opensearch:${OPENSEARCH_TAG}
+
+ARG INSTALL_PLUGIN_ANALYSIS_PHONETIC=true
+ARG INSTALL_PLUGIN_ANALYSIS_ICU=true
+
 WORKDIR /usr/share/opensearch
- 
-RUN bin/opensearch-plugin install analysis-phonetic
-RUN bin/opensearch-plugin install analysis-icu
+
+# Install plugins
+RUN if [ "${INSTALL_PLUGIN_ANALYSIS_PHONETIC}" = "true" ]; then bin/opensearch-plugin install analysis-phonetic; fi
+RUN if [ "${INSTALL_PLUGIN_ANALYSIS_ICU}" = "true" ]; then bin/opensearch-plugin install analysis-icu; fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -51,7 +51,7 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ${ADDON_PATH} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  echo "# ddev add-on get ${ADDON_PATH} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
   ddev get ${ADDON_PATH}
   health_checks
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -48,6 +48,7 @@ teardown() {
   health_checks
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -20,7 +20,7 @@ setup() {
 
 health_checks() {
   set +u # bats-assert has unset variables so turn off unset check
-  # ddev restart is required because we have done `ddev get` on a new service
+  # ddev restart is required because we have done `ddev add-on get` on a new service
   ddev restart
 
   # For debugging purposes
@@ -43,8 +43,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   health_checks
 }
 


### PR DESCRIPTION
Add the following variables:

- OPENSEARCH_TAG -> defines the tag of the used opensearch image
- INSTALL_PLUGIN_ANALYSIS_PHONETIC: boolean var
- INSTALL_PLUGIN_ANALYSIS_ICU: boolean var

docker-compose is now passing the args to the used Dockerfile

## The Issue

Solve #6 

## How This PR Solves The Issue

- Add args to Dockerfile
- Define used build-args in docker-compose.yml

## Manual Testing Instructions

Use new ddev 1.23.5 and define a dotenv file.

```bash
ddev dotenv set .ddev/.env.opensearch --opensearch-tag=2.15.0 --opensearch-dashboards-tag=2.15.0 --install-plugin-analytics-phoenetic=false --install-plugin-analytics-icu=false
ddev add-on get https://github.com/cmuench/ddev-opensearch/tarball/feature/dotenv-support
```

## Related Issue Link(s)

- #3 -> This PR allow to define the used OpenSearch version

## Release/Deployment Notes

It should not have affects.

